### PR TITLE
fix: Do not create a command prompt window when running `wsl.exe`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,14 +88,19 @@ pub fn convert(
     #[cfg(windows)]
     cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
 
-    let output = cmd.output().map_err(|e| format!("Error executing wsl.exe: {}", e))?;
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Error executing wsl.exe: {}", e))?;
 
     let code = output.status.code().unwrap_or(-1);
     if code != 0 {
         return Err(format!("Error getting wslpath: {}", code).into());
     }
     
-    Ok(std::str::from_utf8(&output.stdout).map_err(|e| format!("Error converting output to string: {}", e))?.trim().to_string())
+    Ok(std::str::from_utf8(&output.stdout)
+       .map_err(|e| format!("Error converting output to string: {}", e))?
+       .trim()
+       .to_string())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 
 use std::process::Command;
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 /// Type of conversion to perform
 #[derive(Debug)]
 pub enum Conversion {
@@ -71,17 +74,28 @@ pub fn convert(
         args.push("-a");
     }
 
-    let cmd = Command::new("wsl.exe")
-        .args(args)
-        .arg(path.replace('\\', "\\\\"))
-        .output()?;
+    let mut cmd = Command::new("wsl.exe");
+    cmd.args(args);
+    cmd.arg(path.replace('\\', "\\\\"));
 
-    let code = cmd.status.code().unwrap_or(-1);
+    // Disable window creation on Windows
+    //
+    // This is necessary to prevent a command prompt window from being shown for a short time,
+    // which is likely undesired, especially for GUI applications.
+    //
+    // The flags are documented here:
+    // https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags
+    #[cfg(windows)]
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+
+    let output = cmd.output()?;
+
+    let code = output.status.code().unwrap_or(-1);
     if code != 0 {
         return Err(format!("Error getting wslpath: {}", code).into());
     }
 
-    Ok(std::str::from_utf8(&cmd.stdout)?.trim().to_string())
+    Ok(std::str::from_utf8(&output.stdout)?.trim().to_string())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,9 +98,9 @@ pub fn convert(
     }
 
     Ok(std::str::from_utf8(&output.stdout)
-         .map_err(|e| format!("Error converting output to string: {}", e))?
-         .trim()
-         .to_string())
+        .map_err(|e| format!("Error converting output to string: {}", e))?
+        .trim()
+        .to_string())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub fn convert(
     if force_absolute_path {
         args.push("-a");
     }
-  
+
     let mut cmd = Command::new("wsl.exe");
     cmd.args(args);
     cmd.arg(path.replace('\\', "\\\\"));
@@ -96,11 +96,11 @@ pub fn convert(
     if code != 0 {
         return Err(format!("Error getting wslpath: {}", code).into());
     }
-    
+
     Ok(std::str::from_utf8(&output.stdout)
-       .map_err(|e| format!("Error converting output to string: {}", e))?
-       .trim()
-       .to_string())
+         .map_err(|e| format!("Error converting output to string: {}", e))?
+         .trim()
+         .to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This prevents a CMD window from popping up when running `wsl.exe` (e.g., in a GUI application).